### PR TITLE
Do not reverse tracks in playlists

### DIFF
--- a/src/resources/lib/DeezerApi/playlist.py
+++ b/src/resources/lib/DeezerApi/playlist.py
@@ -30,7 +30,6 @@ class Playlist(DeezerObject):
             if trk['readable']:
                 tracks.append(Track(self.connection, trk))
 
-        tracks.reverse()
         return tracks
 
     def get_picture(self, size=''):


### PR DESCRIPTION
The `reverse()` looks intentional, but I could not think of a reason for that - maybe the API previously returned the tracks in wrong order?

In any case, I think the order of the tracks in the playlist should be the same as shown e.g. with Deezer apps, so the reverse should be removed.